### PR TITLE
Fix broken urls

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,3 @@
 This repo contains the Git pages for the vim-scripts site.
 
-See http://vim-scripts.github.com
+See http://vim-scripts.org

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,11 @@
 markdown: rdiscount
 safe: true
 lsi: false
-pygments: true
+highlighter: pygments
+vim-scripts:
+  organization_url: "https://github.com/vim-scripts/"
+  feed_url: "https://github.com/vim-scripts.atom"
+vim-scraper:
+  repository_url: "https://github.com/vim-scraper/vim-scraper/"
+  issues_url: "https://github.com/vim-scraper/vim-scraper/issues"
+  feed_url: "https://github.com/vim-scraper/vim-scraper/commits/master.atom"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,7 +61,7 @@
         <li class="tools"><a href="/vim/tools.html">Tools</a></li>
         <li class="support"><a href="/vim/support.html">Support</a></li>
         <li class="scripts"><a href="/vim/scripts.html">All Scripts</a></li>
-        <li class="github"><a href="http://github.com/vim-scripts" rel="external">GitHub</a></li>
+        <li class="github"><a href="{{ site.vim-scripts.organization_url }}" rel="external">GitHub</a></li>
       </ul>
     </nav>
   </header>

--- a/feeds/news.xml
+++ b/feeds/news.xml
@@ -1,5 +1,4 @@
 ---
-layout: nil
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/images/feed.svg
+++ b/images/feed.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"> 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="128px" height="128px" id="RSSicon" viewBox="0 0 256 256">
+<defs>
+<linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915" id="RSSg">
+<stop  offset="0.0" stop-color="#E3702D"/><stop  offset="0.1071" stop-color="#EA7D31"/>
+<stop  offset="0.3503" stop-color="#F69537"/><stop  offset="0.5" stop-color="#FB9E3A"/>
+<stop  offset="0.7016" stop-color="#EA7C31"/><stop  offset="0.8866" stop-color="#DE642B"/>
+<stop  offset="1.0" stop-color="#D95B29"/>
+</linearGradient>
+</defs>
+<rect width="256" height="256" rx="55" ry="55" x="0"  y="0"  fill="#CC5D15"/>
+<rect width="246" height="246" rx="50" ry="50" x="5"  y="5"  fill="#F49C52"/>
+<rect width="236" height="236" rx="47" ry="47" x="10" y="10" fill="url(#RSSg)"/>
+<circle cx="68" cy="189" r="24" fill="#FFF"/>
+<path d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z" fill="#FFF"/>
+<path d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z" fill="#FFF"/>
+</svg>

--- a/index.markdown
+++ b/index.markdown
@@ -11,7 +11,7 @@ This mirror provides access to any of the scripts
 [on vim.org](http://www.vim.org/scripts/) using
 [Git](http://git-scm.com/).
 It was inspired by
-[Pathogen's](http://github.com/tpope/vim-pathogen)
+[Pathogen's](https://github.com/tpope/vim-pathogen)
 simple approach to
 [Vim](http://vim.org/) plugins.
 
@@ -19,7 +19,7 @@ simple approach to
 **NOTE: we are in a beta period.**
 We expect that things will be stable from here on out but these repos
 are still too new to be sure.  Enjoy using them and report
-any problems you see on the [issue tracker](http://github.com/vim-scripts/vim-scraper/issues)!
+any problems you see on the [issue tracker]({{ site.vim-scraper.issues_url }})!
 
 
 ### Usage
@@ -34,10 +34,13 @@ Still, it can be even easier.  See [Vim Plugin Managers](/vim/tools.html).
 
 ### Subscribe
 
-* site [news](/vim/news.html) [feed](/feeds/news.xml)![feed](http://github.com/images/icons/feed.png)
-* [scripts feed](http://github.com/vim-scripts.atom)![feed](http://github.com/images/icons/feed.png) or follow the [vim-scripts user](http://github.com/vim-scripts/)
-* [scraper feed](http://github.com/vim-scripts/vim-scraper/commits/master.atom)![feed](http://github.com/images/icons/feed.png) or watch the [vim-scraper](http://github.com/vim-scripts/vim-scraper) project
-* or subscribe to your favorite [scripts](http://github.com/vim-scripts/) feeds 
+* site [news](/vim/news.html)
+  ([feed ![feed](/images/feed.svg =12x)](/feeds/news.xml)),
+* [scripts ![feed](/images/feed.svg =12x)]({{ site.vim-scripts.feed_url }})
+  or follow the [vim-scripts user]({{ site.vim-scripts.organization_url }})
+* [scraper ![feed](/images/feed.svg =12x)]({{ site.vim-scraper.feed_url }})
+  or watch the [vim-scraper]({{ site.vim-scraper.repository_url }}) project
+* or subscribe to your favorite [scripts]({{ site.vim-scripts.organization_url }}) feeds
 
 
 <div id="recent-news">

--- a/vim/faq.markdown
+++ b/vim/faq.markdown
@@ -31,15 +31,15 @@ and we'll fix the scraper and regenerate the script.
 there's little chance the original authors would ever see them.
 Still, it might make sense to be able to file issues anyway.
 This is easy enough to change, we just haven't made a final decision yet.
-Discuss it [here](http://github.com/vim-scripts/vim-scraper/issues/issue/2).
+Discuss it [here]({{ site.vim-scraper.issues_url }}/issue/2).
 
 
 **Q:** I sent you a GitHub messsage.  Why don't you respond?
 
 vim-scripts is just a robot.  The best way to discuss things
 is by filing an issue on either the
-<a href="http://github.com/vim-scripts/vim-scraper/issues">scraper</a> or
-<a href="http://github.com/vim-scripts/vim-scripts.github.com/issues">documentation</a>.
+<a href="{{ site.vim-scraper.issues_url }}">scraper</a> or
+<a href="{{ site.github.issues_url }}">documentation</a>.
 
 **Q:** I sent you a messsage or pull request.  Why don't you respond?
 
@@ -50,7 +50,7 @@ is by filing an issue on either the
 
 **A:** The scripts are updated multiple times per day from the
 RSS feed.  The most recent changes can be seen on the
-<a href="http://github.com/vim-scripts">GitHub page</a>.
+<a href="{{ site.vim-scripts.organization_url }}">GitHub page</a>.
 
 
 ### For Script Developers

--- a/vim/support.markdown
+++ b/vim/support.markdown
@@ -7,11 +7,11 @@ title: Support
 
 Scraper or script issues?  File an issue on the scraper:
 
-* <https://github.com/vim-scraper/vim-scraper/issues>
+* <{{ site.vim-scraper.issues_url }}>
 
 Site issues?  File an issue on the static website:
 
-* <https://github.com/vim-scraper/vim-scraper.github.com/issues>
+* <{{ site.github.issues_url }}>
 
 If you find a security issue or have something that shouldn't appear
 in public, email


### PR DESCRIPTION
This commit fixes a few broken urls on vim-scripts.org.
In addition, I made the following improvements:
- added a local feed icon
- put urls that are used several times in _config.yml
- fixed some jekyll warnings

:warning: I also used some variables specific to github pages (`site.github.issues_url` for the site's issue tracker) which are supposed to be populated automatically but I couldn't test locally.
